### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  statuses: write
+
 env:
   FORCE_COLOR: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/versatiles-org/node-release-tool/security/code-scanning/3](https://github.com/versatiles-org/node-release-tool/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the tasks involve reading repository contents (e.g., fetching code, installing dependencies) and uploading test coverage. Therefore, we will set `contents: read` and `statuses: write` (required for reporting test coverage results). If additional permissions are needed in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
